### PR TITLE
Fix TCAP RA

### DIFF
--- a/resources/tcap/ra/src/main/java/org/mobicents/slee/resource/tcap/wrappers/InvokeEventImpl.java
+++ b/resources/tcap/ra/src/main/java/org/mobicents/slee/resource/tcap/wrappers/InvokeEventImpl.java
@@ -57,7 +57,7 @@ public class InvokeEventImpl extends ComponentEventImpl<Invoke> implements Invok
 	 */
 	@Override
 	public Long getLinkedId() {
-		return this.wrappedComponent.getInvokeId();
+		return this.wrappedComponent.getLinkedId();
 	}
 
 	/*

--- a/resources/tcap/ra/src/main/java/org/mobicents/slee/resource/tcap/wrappers/TCAPDialogWrapper.java
+++ b/resources/tcap/ra/src/main/java/org/mobicents/slee/resource/tcap/wrappers/TCAPDialogWrapper.java
@@ -426,4 +426,9 @@ public class TCAPDialogWrapper implements Dialog, TCAPEvent {
 		return ra;
 	}
 
+	@Override
+	public String toString() {
+		return this.wrappedDialog.toString();
+	}
+
 }


### PR DESCRIPTION
getLinkedId method in InvokeEventImpl now returns the linkedId not the dialogId
